### PR TITLE
galaxy.yml: Adds dependency on ansible.posix (Fixes: #414)

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,6 +20,7 @@ tags:
 dependencies:
   ansible.posix: '>=1.0.0'
   community.crypto: '>=1.0.0'
+  community.general: '>=1.0.0'
 repository: 'https://github.com/dev-sec/ansible-os-hardening'
 homepage: 'https://dev-sec.io/'
 issues: 'https://github.com/dev-sec/ansible-os-hardening/issues'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,6 +18,7 @@ tags:
   - mysql
   - openssh
 dependencies:
+  ansible.posix: '>=1.0.0'
   community.crypto: '>=1.0.0'
 repository: 'https://github.com/dev-sec/ansible-os-hardening'
 homepage: 'https://dev-sec.io/'


### PR DESCRIPTION
This is required by the OS hardening role, which uses the mount module.